### PR TITLE
Add gulp serve task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ gulpfile_dist.js
 redirect.html
 maintenance.html
 splash.css
+.idea/

--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ Running locally requires being built with Gulp.
 3. Install the project's build dependencies with npm: `npm install`
 4. Build with Gulp: `gulp`
 5. Results are located in the /dist/ directory.
+
+### Dev Tools
+
+To ease development, you can use the `gulp serve` command 
+to build the project, start a webserver, and rebuild the project whenever
+a file changes in the project. 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 var gulp = require('gulp');
 var translate = require('gulp-translator');
 var cachebust = require('gulp-cache-bust');
+var connect = require('gulp-connect');
 var del = require('del');
 
 var translations = ['en_US', 'ja_JP', 'fr_FR', 'fr_CA', 'es_ES', 'es_MX'];
@@ -60,5 +61,18 @@ gulp.task('bust', function() {
       .pipe(gulp.dest('dist/' + lang))
   })
 })
+
+gulp.task('webserver', function() {
+  connect.server({
+      root: 'dist'
+  })
+});
+
+gulp.task('watch', function() {
+  const watchedPaths = ['app/**', 'common/**', 'locale/**'];
+  gulp.watch(watchedPaths, '', ['prep', 'localize']);
+});
+
+gulp.task('serve', ['default', 'webserver', 'watch']);
 
 gulp.task('default', ['clean', 'prep', 'localize'])

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "del": "^3.0.0",
     "gulp": "^3.9.1",
     "gulp-cache-bust": "^1.1.0",
+    "gulp-connect": "^5.0.0",
     "gulp-translator": "^0.2.0"
   },
   "scripts": {


### PR DESCRIPTION
When doing development every time I make a change I have to build the project in order to verify the changes I made. 

Now using the `gulp serve` command it starts a webserver and automatically rebuilds the project. I just have to refresh the page on the browser to see my changes.